### PR TITLE
Add test run creation to CDP scripts

### DIFF
--- a/samples/cdp-tests/connectOverCDPScript.js
+++ b/samples/cdp-tests/connectOverCDPScript.js
@@ -17,13 +17,49 @@
 
 import { chromium } from 'playwright';
 import { getCdpEndpoint } from './playwrightServiceClient.js';
+import { randomUUID } from 'crypto';
+import https from 'https';
 
 async function main() {
-  console.log('🔗 Connecting to Microsoft Playwright Service...');
+  // Generate a unique run ID
+  const runId = process.env.PLAYWRIGHT_RUN_ID || randomUUID();
   
-  // Step 1: Get CDP endpoint from the service
+  // Create test run for tracking
+  const match = process.env.PLAYWRIGHT_SERVICE_URL?.match(/^wss:\/\/([^\.]+)\.api\.playwright\.microsoft\.com\/playwrightworkspaces\/([^\/]+)\//); 
+  if (match) {
+    const url = new URL(`https://${match[1]}.reporting.api.playwright.microsoft.com/playwrightworkspaces/${match[2]}/test-runs/${runId}?api-version=2025-09-01`);
+    const payload = JSON.stringify({ displayName: runId, ciConfig: { providerName: 'GITHUB' } });
+    const req = https.request(url, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/merge-patch+json',
+        'Authorization': `Bearer ${process.env.PLAYWRIGHT_SERVICE_ACCESS_TOKEN}`
+      }
+    }, res => {
+      let data = '';
+      res.on('data', chunk => (data += chunk));
+      res.on('end', () => {
+        if (res.statusCode >= 200 && res.statusCode < 300) {
+          console.log(`✅ Test run created: ${runId}`);
+        } else {
+          console.log(`⚠️  Test run creation failed: ${res.statusCode} - ${data}`);
+        }
+      });
+    });
+    req.on('error', err => console.log(`⚠️  Test run creation error: ${err.message}`));
+    req.write(payload);
+    req.end();
+  }
+  
+  console.log('🔗 Connecting to Microsoft Playwright Service...');
+  console.log(`📊 Run ID: ${runId}`);
+  
+  // Step 1: Get CDP endpoint from the service with run ID
   // This step will be simplified once OSS redirect support is added
-  const cdpUrl = await getCdpEndpoint();
+  let cdpUrl = await getCdpEndpoint();
+  // Append run ID to track this session
+  const separator = cdpUrl.includes('?') ? '&' : '?';
+  cdpUrl = `${cdpUrl}${separator}runId=${runId}`;
   console.log('✅ Got CDP endpoint');
   
   // Step 2: Connect to remote browser using Playwright

--- a/samples/cdp-tests/connectOverCDPScript.py
+++ b/samples/cdp-tests/connectOverCDPScript.py
@@ -33,23 +33,46 @@ This demonstrates a NON-TESTING scenario for manual browser automation.
 """
 
 import asyncio
+import os
+import uuid
+import aiohttp
 from playwright.async_api import async_playwright
 from dotenv import load_dotenv
 
 # Load environment variables from .env file
 load_dotenv()
 
-from playwright_service_client import get_cdp_endpoint
+from playwright_service_client import get_cdp_endpoint, _parse_url
 
 
 async def main():
     """Connect to a remote browser via CDP and perform basic operations."""
     
-    print('🔗 Connecting to Microsoft Playwright Service...')
+    # Generate a unique run ID
+    run_id = os.getenv('PLAYWRIGHT_RUN_ID', str(uuid.uuid4()))
     
-    # Step 1: Get CDP endpoint from the service
+    # Create test run for tracking
+    region, workspace_id = _parse_url(os.getenv('PLAYWRIGHT_SERVICE_URL', ''))
+    url = f'https://{region}.reporting.api.playwright.microsoft.com/playwrightworkspaces/{workspace_id}/test-runs/{run_id}?api-version=2025-09-01'
+    payload = {'displayName': run_id, 'ciConfig': {'providerName': 'GITHUB'}}
+    headers = {'Content-Type': 'application/merge-patch+json', 'Authorization': f'Bearer {os.getenv("PLAYWRIGHT_SERVICE_ACCESS_TOKEN", "")}'}
+    async with aiohttp.ClientSession() as session:
+        response = await session.patch(url, json=payload, headers=headers)
+        if response.status >= 200 and response.status < 300:
+            print(f'✅ Test run created: {run_id}')
+        else:
+            text = await response.text()
+            print(f'⚠️  Test run creation failed: {response.status} - {text}')
+    
+    print('🔗 Connecting to Microsoft Playwright Service...')
+    print(f'📊 Run ID: {run_id}')
+    
+    # Step 1: Get CDP endpoint from the service with run ID
     # This step will be simplified once OSS redirect support is added
     cdp_url = await get_cdp_endpoint()
+    # Append run ID to track this session
+    separator = '&' if '?' in cdp_url else '?'
+    cdp_url = f"{cdp_url}{separator}runId={run_id}"
     print(f'✅ Got CDP endpoint')
     
     # Step 2: Connect to remote browser using Playwright


### PR DESCRIPTION
This pull request enhances both the JavaScript and Python CDP connection scripts to support test run tracking by generating a unique run ID, reporting test runs to the Playwright reporting API, and appending the run ID to the CDP endpoint URL. This enables better traceability of test sessions and integration with CI systems.

**Test run tracking and reporting:**

* Both `connectOverCDPScript.js` and `connectOverCDPScript.py` now generate a unique `runId` for each session (using `randomUUID` in JS and `uuid.uuid4()` in Python), and report the test run to the Playwright reporting API using the service credentials and workspace information. This allows each test run to be uniquely tracked and associated with CI metadata. [[1]](diffhunk://#diff-54973b16c51a6419c8a4df2918b6a6b3d1f38a4d8d4c7d3b597102c602973116R20-R62) [[2]](diffhunk://#diff-0a4b3536b01ae871cbcf48a2e7c57c0e4a734a6fd0999e038f5256e73beb9f8eR36-R75)

**Session traceability improvements:**

* The scripts append the generated `runId` as a query parameter to the CDP endpoint URL, ensuring that the remote service can associate browser sessions with the reported test run. [[1]](diffhunk://#diff-54973b16c51a6419c8a4df2918b6a6b3d1f38a4d8d4c7d3b597102c602973116R20-R62) [[2]](diffhunk://#diff-0a4b3536b01ae871cbcf48a2e7c57c0e4a734a6fd0999e038f5256e73beb9f8eR36-R75)

**User feedback and logging:**

* Informative console output is added to display the generated run ID and the result of the test run creation request, improving transparency for users running the scripts. [[1]](diffhunk://#diff-54973b16c51a6419c8a4df2918b6a6b3d1f38a4d8d4c7d3b597102c602973116R20-R62) [[2]](diffhunk://#diff-0a4b3536b01ae871cbcf48a2e7c57c0e4a734a6fd0999e038f5256e73beb9f8eR36-R75)