### PR TITLE
Add CODEOWNERS for repository ownership

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Team-based ownership for the entire repository
+* @Azure/playwright-service


### PR DESCRIPTION
This pull request introduces a small change to the repository's code ownership configuration. The change assigns team-based ownership to the entire repository.

* [`CODEOWNERS`](diffhunk://#diff-fcf14c4b7b34fe7a11916195871ae66a59be87a395f28db73e345ebdc828085bR1-R2): Added `@Azure/playwright-service` as the owner for all files in the repository.